### PR TITLE
"Set" command doesn't correctly updates player health

### DIFF
--- a/src/main/java/me/ichun/mods/limitedlives/common/command/LimitedLivesCommand.java
+++ b/src/main/java/me/ichun/mods/limitedlives/common/command/LimitedLivesCommand.java
@@ -6,6 +6,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import me.ichun.mods.limitedlives.common.LimitedLives;
 import me.ichun.mods.limitedlives.common.core.EntityHelper;
+import me.ichun.mods.limitedlives.common.core.HealthManager;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
@@ -34,6 +35,7 @@ public class LimitedLivesCommand
 
                                 CompoundTag tag = EntityHelper.getPlayerPersistentData(player, "LimitedLivesSave");
                                 tag.putInt("deathCount", deaths);
+                                HealthManager.updatePlayerHealth(player, deaths);
 
                                 source.getSource().sendSuccess(TextComponentHelper.createComponentTranslation(source.getSource().getEntity(), "limitedlives.setDeaths", player.getName().getContents(), deaths), true);
 

--- a/src/main/java/me/ichun/mods/limitedlives/common/core/EventHandler.java
+++ b/src/main/java/me/ichun/mods/limitedlives/common/core/EventHandler.java
@@ -50,11 +50,11 @@ public class EventHandler
     public void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event)
     {
         CompoundTag tag = EntityHelper.getPlayerPersistentData(event.getPlayer(), "LimitedLivesSave");
+        ServerPlayer player = (ServerPlayer)event.getPlayer();
         int deaths = tag.getInt("deathCount");
         if(deaths >= LimitedLives.config.maxLives.get())
         {
             //do ban
-            ServerPlayer player = (ServerPlayer)event.getPlayer();
             MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
             if(LimitedLives.config.banType.get() == LimitedLives.BanType.SPECTATOR || server.isSingleplayer() && server.getSingleplayerName().equals(player.getName().getContents()))
             {
@@ -73,8 +73,7 @@ public class EventHandler
         }
         else if(LimitedLives.config.healthAdjust.get())
         {
-            double nextHealth = Math.max(20 - (deaths / (double)LimitedLives.config.maxLives.get() * 20D) + tag.getDouble("healthOffset"), 1D);
-            event.getPlayer().getAttribute(Attributes.MAX_HEALTH).setBaseValue(nextHealth);
+            HealthManager.updatePlayerHealth(player, deaths);
         }
     }
 

--- a/src/main/java/me/ichun/mods/limitedlives/common/core/HealthManager.java
+++ b/src/main/java/me/ichun/mods/limitedlives/common/core/HealthManager.java
@@ -1,0 +1,38 @@
+package me.ichun.mods.limitedlives.common.core;
+
+import me.ichun.mods.limitedlives.common.LimitedLives;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+
+public class HealthManager {
+
+    private static final int MAX_DEFAULT_HEALTH = 20;
+
+    /**
+     * Updates the player's max health based on the number of deaths they have.
+     * @param player player we are updating the health of
+     * @param deaths number of deaths the player has
+     */
+    public static void updatePlayerHealth(ServerPlayer player, int deaths) {
+        int newHealth = calculateNewHealth(deaths);
+        AttributeInstance healthAttribute = player.getAttribute(Attributes.MAX_HEALTH);
+        
+        if (healthAttribute != null) {
+            healthAttribute.setBaseValue(Math.max(newHealth, 1D));
+        }
+    }
+
+    private static int calculateNewHealth(int deaths) {
+        int maxLives = LimitedLives.config.maxLives.get();
+        int totalPlayerLivesLeft = maxLives - deaths;
+
+        double healthPerLife = (double) MAX_DEFAULT_HEALTH / (double) maxLives;
+
+        return (int) (totalPlayerLivesLeft * healthPerLife);
+    }
+
+    private HealthManager() {
+    }
+
+}

--- a/src/main/java/me/ichun/mods/limitedlives/common/core/HealthManager.java
+++ b/src/main/java/me/ichun/mods/limitedlives/common/core/HealthManager.java
@@ -21,6 +21,10 @@ public class HealthManager {
         if (healthAttribute != null) {
             healthAttribute.setBaseValue(Math.max(newHealth, 1D));
         }
+
+        if (player.getHealth() > newHealth) {
+            player.setHealth(newHealth);
+        }
     }
 
     private static int calculateNewHealth(int deaths) {


### PR DESCRIPTION
`/ll set {player} {deaths}` has two issues:
* **Health is not updated immediately**.
* **Health would desync with total player deaths**: when reducing the total amount of deaths of a player, total health would not correspond correctly to amount fo lives of the player. 

This PR fixes those issues